### PR TITLE
docs: Prevent downstream commits from landing on template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,25 @@ This project uses npm scripts for all development tasks:
 
 If user is asking you to pull in updates from the upstream repository, you can do so by following these steps:
 
+### Step 0: Ensure Upstream Is Fetch-Only
+
+**Never push to `upstream`** — it points to `peerigon/template`, a shared repository. A downstream project's commits must never land there. Before running any upstream commands, make sure the push URL is disabled:
+
+```bash
+git remote -v
+# If `upstream` shows a real push URL, disable it:
+git remote set-url --push upstream DISABLED
+```
+
+With this set, any accidental `git push upstream …` fails immediately instead of silently publishing downstream code to the public template.
+
+If `upstream` is not yet configured at all, add it this way:
+
+```bash
+git remote add upstream https://github.com/peerigon/template.git
+git remote set-url --push upstream DISABLED
+```
+
 ### Step 1: Merge Template Updates
 
 ```bash


### PR DESCRIPTION
## Summary

- Add a **Step 0** to the "Pulling Updates from Upstream" section that disables the `upstream` remote's push URL (`git remote set-url --push upstream DISABLED`).
- State explicitly that `upstream` is fetch-only.

## Why

Downstream projects add this repo as their `upstream` remote. By default, `git remote add upstream …` configures both fetch **and push** URLs. That lets a stray `git push upstream main` (from a human, or an AI agent running `git push` without thinking) publish a downstream project's commits onto `peerigon/template`'s main branch.

This actually happened — it was recoverable via admin force-push, but a lightweight guardrail prevents recurrence at the source.

With the push URL set to `DISABLED`, any accidental push fails immediately:

```
fatal: 'DISABLED' does not appear to be a git repository
```

…instead of silently succeeding against a public template repo.

## Test plan

- [ ] Read through the new Step 0 — wording is clear and the commands are correct
- [ ] In a test repo, run the `git remote set-url --push upstream DISABLED` command and confirm `git push upstream` now fails fast while `git fetch upstream` still works
- [ ] (Optional, separate follow-up) Enable branch protection on `peerigon/template`'s `main` to require PRs, so direct pushes are rejected server-side as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)