### PR TITLE
chore: Enforce strict peer deps to catch bad dependabot PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231 # main
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # main
         with:
           persist-credentials: false
 
@@ -51,7 +51,7 @@ jobs:
       - name: 🔍 Install dependencies
         if: steps.cache-node_modules.outputs.cache-hit != 'true'
         run: |
-          npm ci --ignore-scripts --prefer-offline --no-audit
+          npm ci --ignore-scripts --prefer-offline --no-audit --strict-peer-deps
 
       - name: 🧪 Run tests
         env:

--- a/.npmrc
+++ b/.npmrc
@@ -8,3 +8,6 @@ allow-git=none
 
 # Security hardening: skip package versions published less than 7 days ago (based on CISA's guidance).
 min-release-age=7
+
+# Fail on peer dependency conflicts so dependabot PRs with broken peer deps are rejected.
+strict-peer-deps=true


### PR DESCRIPTION
## Summary

- Adds `strict-peer-deps=true` to `.npmrc` so dependabot fails when generating a lock file with peer dependency conflicts, preventing such PRs from being created in the first place
- Adds `--strict-peer-deps` to `npm ci` in the test workflow as a safety net — any conflict that slips through will cause CI to fail

## Test plan

- [ ] Verify the test workflow passes on this PR
- [ ] Confirm a future dependabot PR with peer dep conflicts is either blocked or fails CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)