### PR TITLE
fix: correct required status check name in main branch ruleset

### DIFF
--- a/.github/rulesets/protect-main-branch.json
+++ b/.github/rulesets/protect-main-branch.json
@@ -36,7 +36,7 @@
         "do_not_enforce_on_create": false,
         "required_status_checks": [
           {
-            "context": "test",
+            "context": "🧪 Test",
             "integration_id": 15368
           }
         ]


### PR DESCRIPTION
## Summary
- The `protect-main-branch.json` ruleset blueprint required a status check named `test`, which didn't match the actual GitHub Actions job name `🧪 Test` defined in `test.yml`.
- Updated the `context` field to `🧪 Test` so once this ruleset is imported/enabled, the CI test job actually blocks merges when it fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)