### PR TITLE
docs: document PR base-branch pitfall for forked template projects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,18 @@ git remote set-url --push template DISABLED
 
 Verify with `git remote -v`: `template` should show a normal fetch URL and `DISABLED` (or empty) for push.
 
+## Opening pull requests
+
+Projects generated from this template are **GitHub forks** of `peerigon/template`, so both the web UI's compare page and a fresh `gh` checkout default a new pull request's base to the **upstream** repo (`peerigon/template`). A PR opened that way targets the template, and checks that depend on the fork's repo (CODEOWNERS, rulesets) then fail against the wrong repository.
+
+Run this once per clone of the forked repo:
+
+```bash
+gh repo set-default <owner>/<repo>
+```
+
+After that `gh pr create` targets the fork. The web UI keeps preselecting the upstream — always confirm the base is `<owner>/<repo>` before creating a PR there, or use `gh pr create --repo <owner>/<repo>`.
+
 ## Pulling Updates from Template
 
 If the user is asking you to pull in updates from the template repository, follow the steps below.


### PR DESCRIPTION
## Summary
- Add an "Opening pull requests" section to AGENTS.md explaining that downstream forks of `peerigon/template` default new PRs to the upstream repo (via `gh` or the GitHub web UI), which breaks fork-specific checks like CODEOWNERS and rulesets.
- Documents the fix: run `gh repo set-default <owner>/<repo>` once per clone, or pass `--repo <owner>/<repo>` explicitly.

Adapted from [peerigon/leitstand#34bc583](https://github.com/peerigon/leitstand/commit/34bc5837defc74ecc3353f273f3c6ee91d3e25b8), generalized since this repo is the template itself rather than a fork.

## Test plan
- [x] Reviewed rendered Markdown for formatting